### PR TITLE
Add world-based LG lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,8 +24,9 @@
 
 	</div>
 	<div id="cc-m-8396781875" class="j-module n j-htmlCode ">
-		<div id="wscript" align="center">
-			<div class="LGListItem dummyItem">
+                <div id="wscript" align="center">
+                       <button id="addWorld">+</button>
+                        <div class="LGListItem dummyItem">
 				<select type="text" class="LGListItemName">
 					<option value="3"> Aachener Dom </option>
 					<option value="8"> Alcatraz </option>
@@ -81,11 +82,9 @@
 				<button class="LGListItemMinus">-</button>
 				<button class="LGListItemActive">></button>
 			</div>
-			<div id="LGList"></div>
+                       <div id="worldsContainer"></div>
 
-			<label class="totbox">FP-∑:</label> <label class="totbox" id="totalfpdisplay">70</label> &nbsp;
-			<button id="addLGToList">+</button>
-			<button id="removeLGfromList">-</button>
+                       <label class="totbox">FP-∑:</label> <label class="totbox" id="totalfpdisplay">70</label> &nbsp;
 
 
 			<br>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,6 @@
 	</div>
 	<div id="cc-m-8396781875" class="j-module n j-htmlCode ">
                 <div id="wscript" align="center">
-                       <button id="addWorld">+</button>
                         <div class="LGListItem dummyItem">
 				<select type="text" class="LGListItemName">
 					<option value="3"> Aachener Dom </option>

--- a/src/script.js
+++ b/src/script.js
@@ -4,7 +4,7 @@ let worldData = readWorldData();
 $(document).ready(function () {
     initWorlds();
 
-    $('#addWorld').click(function () {
+    $(document).on('click', '.addWorld', function () {
         const newWorld = prompt('Welt Name?');
         if (!newWorld) return;
         if (!worldData.worlds[newWorld]) {
@@ -31,11 +31,15 @@ $(document).ready(function () {
 function initWorlds() {
     const container = $('#worldsContainer');
     container.empty();
-    Object.keys(worldData.worlds).forEach(world => {
+    Object.keys(worldData.worlds).forEach((world, idx) => {
         const block = $('<div class="worldBlock"></div>').attr('data-world', world);
         const header = $('<h3></h3>').text(world);
         const removeBtn = $('<button class="removeWorld">-</button>');
         header.append(' ').append(removeBtn);
+        if (idx === 0) {
+            const addWorldBtn = $('<button class="addWorld">+</button>');
+            header.append(' ').append(addWorldBtn);
+        }
         block.append(header);
         const list = $('<div class="LGList"></div>');
         block.append(list);
@@ -60,6 +64,10 @@ function initWorlds() {
             removeLGfromList(world);
         });
     });
+
+    const firstActive = $('.usedForCalculation').first();
+    $('.usedForCalculation').not(firstActive).removeClass('usedForCalculation');
+    Object.keys(worldData.worlds).forEach(w => saveLGList(w));
 }
 
 //Cookie
@@ -129,7 +137,7 @@ function initLGList(world, listContainer) {
         $('#p4factor').val(listItem.data('Factors')[3]);
         $('#p5factor').val(listItem.data('Factors')[4]);
 
-        saveLGList(world);
+        Object.keys(worldData.worlds).forEach(w => saveLGList(w));
         recalc();
     });
 

--- a/src/script.js
+++ b/src/script.js
@@ -1,152 +1,206 @@
-// Custom changes. 
-$(document).ready(function () {
-    initLGList();
+// Custom changes.
+let worldData = readWorldData();
 
-    //Add new LG
-    $('#addLGToList').click(() => { addLGToList() });
-    $('#removeLGfromList').click(() => { removeLGfromList() });
-    $('#LGList').change(() => { saveLGList() });
+$(document).ready(function () {
+    initWorlds();
+
+    $('#addWorld').click(function () {
+        const newWorld = prompt('Welt Name?');
+        if (!newWorld) return;
+        if (!worldData.worlds[newWorld]) {
+            worldData.worlds[newWorld] = null;
+            writeWorldData(worldData);
+            initWorlds();
+        }
+    });
+
     $('#externaltable').change(() => {
         $('.usedForCalculation').data('Externals', [$('#external1').val(), $('#external2').val(), $('#external3').val(), $('#external4').val(), $('#external5').val()]);
-        saveLGList()
+        const world = $('.usedForCalculation').closest('.worldBlock').data('world');
+        if (world) saveLGList(world);
     });
 
     $('#p1factor, #p2factor, #p3factor, #p4factor, #p5factor').change(() => {
         $('.usedForCalculation').data('Factors', [$('#p1factor').val(), $('#p2factor').val(), $('#p3factor').val(), $('#p4factor').val(), $('#p5factor').val()]);
-        saveLGList()
+        const world = $('.usedForCalculation').closest('.worldBlock').data('world');
+        if (world) saveLGList(world);
     });
 });
 
+// Build world blocks
+function initWorlds() {
+    const container = $('#worldsContainer');
+    container.empty();
+    Object.keys(worldData.worlds).forEach(world => {
+        const block = $('<div class="worldBlock"></div>').attr('data-world', world);
+        const header = $('<h3></h3>').text(world);
+        const removeBtn = $('<button class="removeWorld">-</button>');
+        header.append(' ').append(removeBtn);
+        block.append(header);
+        const list = $('<div class="LGList"></div>');
+        block.append(list);
+        const addBtn = $('<button class="addLGToList">+</button>');
+        const remBtn = $('<button class="removeLGfromList">-</button>');
+        block.append(addBtn).append(remBtn);
+        container.append(block);
+
+        initLGList(world, list);
+
+        removeBtn.click(function () {
+            if (Object.keys(worldData.worlds).length <= 1) return;
+            deleteCookie(world);
+            initWorlds();
+        });
+
+        addBtn.click(function () {
+            addLGToList(world);
+        });
+
+        remBtn.click(function () {
+            removeLGfromList(world);
+        });
+    });
+}
+
 //Cookie
-function initLGList() {
-    $('#LGList').empty();
-    var LGList = readCookie();
+function initLGList(world, listContainer) {
+    listContainer.empty();
+    var LGList = readCookie(world);
 
-    if (LGList !== null) {
-        for (let i of LGList) {
-            let tempListItem = $('.LGListItem.dummyItem').clone();
-            tempListItem.removeClass('dummyItem');
-
-            tempListItem.find('.LGListItemName option:contains("' + i.LG + '")').prop('selected', true);
-            tempListItem.find('.LGListItemLevel').val(i.Level);
-            tempListItem.data('Externals', i.External);
-            tempListItem.data('Factors', i.Factor);
-            if (i.Active) {
-                tempListItem.addClass('usedForCalculation');
-            }
-
-            tempListItem.appendTo('#LGList');
-        }
-        recalc();
-
-        //Increase level - Event listener
-        $('.LGListItemPlus').click(function () {
-            let itemLevel = $(this).prev().val();
-            itemLevel++
-            $(this).prev().val(itemLevel);
-            $('#external1, #external2, #external3, #external4, #external5').val('0');
-            $('.usedForCalculation').data('Externals', [0, 0, 0, 0, 0]);
-            saveLGList();
-        });
-
-        //Decrease level - Event listener
-        $('.LGListItemMinus').click(function () {
-            let itemLevel = $(this).prev().prev().val();
-            itemLevel--;
-            $(this).prev().prev().val(itemLevel);
-            $('#external1, #external2, #external3, #external4, #external5').val('0');
-            $('.usedForCalculation').data('Externals', [0, 0, 0, 0, 0]);
-            saveLGList();
-        });
-
-        //Activate LG - Event listener
-        $('.LGListItemActive').click(function () {
-            $('.usedForCalculation').removeClass('usedForCalculation');
-
-            let listItem = $(this).parent();
-            listItem.addClass('usedForCalculation');
-
-            // Set the external players based on the saved values for the LG
-            $('#external1').val(listItem.data('Externals')[0]);
-            $('#external2').val(listItem.data('Externals')[1]);
-            $('#external3').val(listItem.data('Externals')[2]);
-            $('#external4').val(listItem.data('Externals')[3]);
-            $('#external5').val(listItem.data('Externals')[4]);
-
-            // Set calculation factors based on the saved values for the LG
-            $('#p1factor').val(listItem.data('Factors')[0]);
-            $('#p2factor').val(listItem.data('Factors')[1]);
-            $('#p3factor').val(listItem.data('Factors')[2]);
-            $('#p4factor').val(listItem.data('Factors')[3]);
-            $('#p5factor').val(listItem.data('Factors')[4]);
-
-            saveLGList();
-            recalc();
-        });
-
-    } else {
-        //Create an LG list
-        addLGToList();
+    if (LGList === null) {
+        LGList = [{ LG: "Arche", Level: 1, Active: true, External: [0, 0, 0, 0, 0], Factor: [1.9, 1.9, 1.9, 1.9, 1.9] }];
+        writeCookie(world, LGList);
     }
+
+    for (let i of LGList) {
+        let tempListItem = $('.LGListItem.dummyItem').clone();
+        tempListItem.removeClass('dummyItem');
+
+        tempListItem.find('.LGListItemName option:contains("' + i.LG + '")').prop('selected', true);
+        tempListItem.find('.LGListItemLevel').val(i.Level);
+        tempListItem.data('Externals', i.External);
+        tempListItem.data('Factors', i.Factor);
+        if (i.Active) {
+            tempListItem.addClass('usedForCalculation');
+        }
+
+        tempListItem.appendTo(listContainer);
+    }
+    recalc();
+
+    //Increase level - Event listener
+    listContainer.find('.LGListItemPlus').click(function () {
+        let itemLevel = $(this).prev().val();
+        itemLevel++;
+        $(this).prev().val(itemLevel);
+        $('#external1, #external2, #external3, #external4, #external5').val('0');
+        $('.usedForCalculation').data('Externals', [0, 0, 0, 0, 0]);
+        saveLGList(world);
+    });
+
+    //Decrease level - Event listener
+    listContainer.find('.LGListItemMinus').click(function () {
+        let itemLevel = $(this).prev().prev().val();
+        itemLevel--;
+        $(this).prev().prev().val(itemLevel);
+        $('#external1, #external2, #external3, #external4, #external5').val('0');
+        $('.usedForCalculation').data('Externals', [0, 0, 0, 0, 0]);
+        saveLGList(world);
+    });
+
+    //Activate LG - Event listener
+    listContainer.find('.LGListItemActive').click(function () {
+        $('.usedForCalculation').removeClass('usedForCalculation');
+
+        let listItem = $(this).parent();
+        listItem.addClass('usedForCalculation');
+
+        // Set the external players based on the saved values for the LG
+        $('#external1').val(listItem.data('Externals')[0]);
+        $('#external2').val(listItem.data('Externals')[1]);
+        $('#external3').val(listItem.data('Externals')[2]);
+        $('#external4').val(listItem.data('Externals')[3]);
+        $('#external5').val(listItem.data('Externals')[4]);
+
+        // Set calculation factors based on the saved values for the LG
+        $('#p1factor').val(listItem.data('Factors')[0]);
+        $('#p2factor').val(listItem.data('Factors')[1]);
+        $('#p3factor').val(listItem.data('Factors')[2]);
+        $('#p4factor').val(listItem.data('Factors')[3]);
+        $('#p5factor').val(listItem.data('Factors')[4]);
+
+        saveLGList(world);
+        recalc();
+    });
+
+    listContainer.change(() => { saveLGList(world); });
 }
 
 // Save current state of the LG list to a cookie
-function saveLGList() {
+function saveLGList(world) {
     let tempLGList = [];
-    $('#LGList div').each(function () {
+    $(`.worldBlock[data-world="${world}"] .LGList .LGListItem`).each(function () {
         let LGName = $(this).find('.LGListItemName option:selected').prop('innerText');
         let LGLevel = $(this).find('.LGListItemLevel').val();
         let LGActive = $(this).hasClass('usedForCalculation');
-        let LGExternal = $(this).data('Externals')
-        let LGFactors = $(this).data('Factors');;
+        let LGExternal = $(this).data('Externals');
+        let LGFactors = $(this).data('Factors');
 
         tempLGList.push({ LG: LGName, Level: LGLevel, Active: LGActive, External: LGExternal, Factor: LGFactors });
-    })
-    writeCookie(tempLGList);
+    });
+    writeCookie(world, tempLGList);
     recalc();
 }
 
 
 //Add / remove new line
-function addLGToList() {
-    var LGList = readCookie();
+function addLGToList(world) {
+    var LGList = readCookie(world);
     if (LGList !== null) {
         LGList.push({ LG: "Arche", Level: 1, Active: false, External: [0, 0, 0, 0, 0], Factor: [1.9, 1.9, 1.9, 1.9, 1.9] });
     } else {
         LGList = [{ LG: "Arche", Level: 1, Active: true, External: [0, 0, 0, 0, 0], Factor: [1.9, 1.9, 1.9, 1.9, 1.9] }];
     }
 
-    writeCookie(LGList);
-    initLGList();
+    writeCookie(world, LGList);
+    initWorlds();
 }
 
-function removeLGfromList() {
-    var LGList = readCookie();
+function removeLGfromList(world) {
+    var LGList = readCookie(world);
+    if (!LGList || LGList.length === 0) return;
 
     LGList.pop();
 
-    writeCookie(LGList);
-    initLGList();
+    writeCookie(world, LGList);
+    initWorlds();
 }
 
 //Save/Read/Delete Cookie
-function writeCookie(value) {
-    var name = "LGListStorage";
-    var cookie = JSON.stringify(value);
-    localStorage.setItem(name, cookie);
+function writeCookie(world, value) {
+    worldData.worlds[world] = value;
+    writeWorldData(worldData);
 }
 
-function readCookie() {
-    var name = "LGListStorage";
-    var value = localStorage.getItem(name);
-    var result = JSON.parse(value);
-    return result;
-
+function readCookie(world) {
+    return worldData.worlds[world];
 }
 
-function deleteCookie() {
-    var name = "LGListStorage";
-    document.cookie = [name, '=; expires=Thu, 01-Jan-1970 00:00:01 GMT; path=/;'].join('');
+function deleteCookie(world) {
+    delete worldData.worlds[world];
+    writeWorldData(worldData);
+}
+
+function readWorldData() {
+    let value = localStorage.getItem('LGWorldData');
+    if (!value) {
+        return { worlds: { 'Standard': null } };
+    }
+    return JSON.parse(value);
+}
+
+function writeWorldData(data) {
+    localStorage.setItem('LGWorldData', JSON.stringify(data));
 }
 
 // Set to 1,94, 1,93 or 1,9
@@ -198,19 +252,21 @@ setInterval(function () {
 }, 5000);
 
 // Increase / Decrease value of LB factor in arcboosttable
-$('*:is(#p1factor, #p2factor, #p3factor, #p4factor, #p5factor) ~ .increaseFactor').click(function() { 
+$('*:is(#p1factor, #p2factor, #p3factor, #p4factor, #p5factor) ~ .increaseFactor').click(function() {
     $(this).parent().find(':input').val((i, val) => { return parseFloat(val) + 0.01})
-    $('.usedForCalculation').data('Factors', [$('#p1factor').val(), $('#p2factor').val(), $('#p3factor').val(), $('#p4factor').val(), $('#p5factor').val()]);  
-    saveLGList();
-    recalc();
- });
-
- $('*:is(#p1factor, #p2factor, #p3factor, #p4factor, #p5factor) ~ .decreaseFactor').click(function() { 
-    $(this).parent().find(':input').val((i, val) => { return parseFloat(val) - 0.01})  
     $('.usedForCalculation').data('Factors', [$('#p1factor').val(), $('#p2factor').val(), $('#p3factor').val(), $('#p4factor').val(), $('#p5factor').val()]);
-    saveLGList();
+    const world = $('.usedForCalculation').closest('.worldBlock').data('world');
+    if (world) saveLGList(world);
     recalc();
- });
+});
+
+$('*:is(#p1factor, #p2factor, #p3factor, #p4factor, #p5factor) ~ .decreaseFactor').click(function() {
+    $(this).parent().find(':input').val((i, val) => { return parseFloat(val) - 0.01})
+    $('.usedForCalculation').data('Factors', [$('#p1factor').val(), $('#p2factor').val(), $('#p3factor').val(), $('#p4factor').val(), $('#p5factor').val()]);
+    const world = $('.usedForCalculation').closest('.worldBlock').data('world');
+    if (world) saveLGList(world);
+    recalc();
+});
 
 
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,19 +1,32 @@
 #container {
     margin: 0 auto;
-    width: 600px;
+    width: 100%;
+    max-width: 600px;
 
 }
 
 #worldsContainer {
     margin: 0 auto;
-    width: 600px;
+    width: 100%;
+    max-width: 600px;
 }
 
 .worldBlock {
-    border: thin solid;
+    border: thin solid #ccc;
     background-color: #f2f2f2;
-    padding: 0.5em;
-    margin: 0.5em 0;
+    padding: 0.25em;
+    margin: 0.25em 0;
+}
+
+.worldBlock h3 {
+    margin: 0 0 0.2em 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.worldBlock h3 button {
+    margin-left: 0.2em;
 }
 
 h1 {

--- a/src/styles.css
+++ b/src/styles.css
@@ -4,6 +4,18 @@
 
 }
 
+#worldsContainer {
+    margin: 0 auto;
+    width: 600px;
+}
+
+.worldBlock {
+    border: thin solid;
+    background-color: #f2f2f2;
+    padding: 0.5em;
+    margin: 0.5em 0;
+}
+
 h1 {
     font-size: 2em;
     font-family: Helvetica, Arial, sans-serif;

--- a/src/styles.css
+++ b/src/styles.css
@@ -12,16 +12,15 @@
 }
 
 .worldBlock {
-    border: thin solid #ccc;
-    background-color: #f2f2f2;
     padding: 0.25em;
     margin: 0.25em 0;
 }
 
 .worldBlock h3 {
     margin: 0 0 0.2em 0;
+    font-size: 1.1em;
+    font-weight: bold;;
     display: flex;
-    justify-content: space-between;
     align-items: center;
 }
 


### PR DESCRIPTION
## Summary
- show each world's LG list inline instead of using a world selector
- persist LG lists per world in localStorage

## Testing
- `node --check src/script.js`


------
https://chatgpt.com/codex/tasks/task_e_688d104578b8832f965a0f131053993a